### PR TITLE
fixed location path for hazelcast schema

### DIFF
--- a/finish/src/main/liberty/config/hazelcast-config.xml
+++ b/finish/src/main/liberty/config/hazelcast-config.xml
@@ -13,7 +13,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.hazelcast.com/schema/config
-       https://hazelcast.com/schema/config/hazelcast-config.xsd">
+       https://hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
     <!-- tag::group[] -->
     <group>
     <!-- tag::cartCluster[] -->


### PR DESCRIPTION
Invalid schema location in the hazelcast config causing this warning message: 
```bash
[WARNING ] Name of the hazelcast schema location is incorrect, using default
```